### PR TITLE
Adjustment and UI fix

### DIFF
--- a/app/controller.go
+++ b/app/controller.go
@@ -613,7 +613,10 @@ func (m *State) LoadSession(msg loadSessionMsg) (tea.Model, tea.Cmd) {
 
 	session.Apply(m)
 
-	return m, sendMsg(setActivityMsg("Session loaded from " + msg.path))
+	return m, tea.Batch(
+		sendMsg(setActivityMsg("Session loaded from "+msg.path)),
+		sendMsg(recalculateComponentSizesMsg{}),
+	)
 }
 
 func (m *State) LoadSessionList() (tea.Model, tea.Cmd) {

--- a/app/logger.go
+++ b/app/logger.go
@@ -3,6 +3,7 @@ package app
 import (
 	"log/slog"
 	"os"
+	"path/filepath"
 )
 
 type Logger struct {
@@ -11,6 +12,14 @@ type Logger struct {
 }
 
 func newLogger(path string) (*Logger, error) {
+	fileDir := filepath.Dir(path)
+	if _, err := os.Stat(fileDir); os.IsNotExist(err) {
+		err = os.MkdirAll(fileDir, 0o755)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return nil, err

--- a/app/vars.go
+++ b/app/vars.go
@@ -16,8 +16,7 @@ var (
 	tempFilePath       = fmt.Sprintf("%s/temp", configFolder)
 	defaultSessionPath = fmt.Sprintf("%s/session.json", configFolder)
 	// debugLogPath       = fmt.Sprintf("%s/debug.log", configFolder)
-	// errorDebugLogPath  = fmt.Sprintf("%s/error.log", configFolder)
-	errorDebugLogPath = "error.log"
+	errorDebugLogPath = fmt.Sprintf("%s/error.log", configFolder)
 	homeLayout        = []string{
 		STATE_FOCUS_URL,
 		STATE_FOCUS_PIPE,


### PR DESCRIPTION
- Move the `error.log` to proper place (inside `./.mayohttp` folder instead of on the workspace root)
- Fix some field glitching on initial run when there's session with long text